### PR TITLE
Fixed: missing "var" was throwing an error on product page

### DIFF
--- a/view/frontend/web/js/model/skuswitch.js
+++ b/view/frontend/web/js/model/skuswitch.js
@@ -51,7 +51,7 @@ define([
 
 					// Set all attributes if we have some
 					if(attrs != undefined) {
-						for(a in attrs) {
+						for(var a in attrs) {
 							$placeholder.attr(a, attrs[a]);
 						}
 					}


### PR DESCRIPTION
Fixed: missing `var` was throwing an error on product page

```Uncaught ReferenceError: a is not defined
at $.(anonymous function).(anonymous function).<anonymous> (....../default/en_US/Andering_ConfigurableDynamic/js/model/skuswitch.js:54:11)
at $.(anonymous function).(anonymous function)._reloadPrice (....../default/en_US/mage/utils/wrapper.js:78:32)
at $.(anonymous function).(anonymous function)._configureElement (....../default/en_US/Magento_ConfigurableProduct/js/configurable.js:286:18)
at $.(anonymous function).(anonymous function)._configureElement (....../default/en_US/jquery/jquery-ui.js:402:25)
at $.(anonymous function).(anonymous function).<anonymous> (....../default/en_US/Magento_ConfigurableProduct/js/configurable.js:223:26)
at HTMLSelectElement.proxy (jquery.js:529)
at Function.each (jquery.js:370)
at jQuery.fn.init.each (jquery.js:137)
at $.(anonymous function).(anonymous function)._configureForValues (....../default/en_US/Magento_ConfigurableProduct/js/configurable.js:220:39)
at $.(anonymous function).(anonymous function)._configureForValues (....../default/en_US/jquery/jquery-ui.js:402:25)```